### PR TITLE
Fix quirkiness with interactive triggers and reply messages

### DIFF
--- a/nhitomi/Discord/FeedChannelUpdateService.cs
+++ b/nhitomi/Discord/FeedChannelUpdateService.cs
@@ -170,7 +170,8 @@ namespace nhitomi.Discord
                         await _interactive.SendInteractiveAsync(
                             new DoujinMessage(doujin, true),
                             context,
-                            cancellationToken);
+                            cancellationToken,
+                            false);
 
                         _logger.LogInformation("Sent feed update of doujin {0} '{1}'.",
                             doujin.Id, doujin.OriginalName);

--- a/nhitomi/Discord/MessageHandlerService.cs
+++ b/nhitomi/Discord/MessageHandlerService.cs
@@ -27,7 +27,7 @@ namespace nhitomi.Discord
     public enum MessageEvent
     {
         Create,
-        Read,
+        Modify,
         Delete
     }
 
@@ -81,7 +81,7 @@ namespace nhitomi.Discord
             HandleMessageAsync(message, MessageEvent.Create);
 
         Task MessageUpdated(Cacheable<IMessage, ulong> _, SocketMessage message, IMessageChannel channel) =>
-            HandleMessageAsync(message, MessageEvent.Read);
+            HandleMessageAsync(message, MessageEvent.Modify);
 
         Task MessageDeleted(Cacheable<IMessage, ulong> cacheable, ISocketMessageChannel channel) =>
             cacheable.HasValue

--- a/nhitomi/Discord/MessageHandlerService.cs
+++ b/nhitomi/Discord/MessageHandlerService.cs
@@ -88,7 +88,6 @@ namespace nhitomi.Discord
                 ? HandleMessageAsync(cacheable.Value, MessageEvent.Delete)
                 : Task.CompletedTask;
 
-
         public readonly AtomicCounter HandledMessages = new AtomicCounter();
         public readonly AtomicCounter ReceivedMessages = new AtomicCounter();
 

--- a/nhitomi/Discord/MessageHandlerService.cs
+++ b/nhitomi/Discord/MessageHandlerService.cs
@@ -8,6 +8,7 @@ using Discord.WebSocket;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using nhitomi.Core;
+using nhitomi.Interactivity;
 
 namespace nhitomi.Discord
 {
@@ -42,7 +43,7 @@ namespace nhitomi.Discord
         [SuppressMessage("ReSharper", "SuggestBaseTypeForParameter")]
         public MessageHandlerService(DiscordService discord, GuildSettingsCache guildSettingsCache,
             DiscordErrorReporter errorReporter, ILogger<MessageHandlerService> logger, CommandExecutor commandExecutor,
-            GalleryUrlDetector galleryUrlDetector)
+            GalleryUrlDetector galleryUrlDetector, InteractiveManager interactiveManager)
         {
             _discord = discord;
             _guildSettingsCache = guildSettingsCache;
@@ -52,7 +53,8 @@ namespace nhitomi.Discord
             _messageHandlers = new IMessageHandler[]
             {
                 commandExecutor,
-                galleryUrlDetector
+                galleryUrlDetector,
+                interactiveManager
             };
         }
 

--- a/nhitomi/Interactivity/EmbedMessage.cs
+++ b/nhitomi/Interactivity/EmbedMessage.cs
@@ -10,6 +10,14 @@ namespace nhitomi.Interactivity
 {
     public interface IEmbedMessage
     {
+        /// <summary>
+        /// The user which caused this interactive to be sent i.e. the author of a command.
+        /// </summary>
+        IUser Source { get; }
+
+        /// <summary>
+        /// The message this interactive is operating on.
+        /// </summary>
         IUserMessage Message { get; }
 
         Task<bool> UpdateViewAsync(IServiceProvider services, CancellationToken cancellationToken = default);
@@ -18,6 +26,7 @@ namespace nhitomi.Interactivity
     public abstract class EmbedMessage<TView> : IEmbedMessage
         where TView : EmbedMessage<TView>.ViewBase
     {
+        public IUser Source { get; private set; }
         public IUserMessage Message { get; private set; }
 
         static readonly DependencyFactory<TView> _viewFactory = DependencyUtility<TView>.Factory;
@@ -29,6 +38,8 @@ namespace nhitomi.Interactivity
             var view = _viewFactory(services);
             view.Message = this;
             view.Context = services.GetRequiredService<IDiscordContext>();
+
+            Source = view.Context.User;
 
             // update the view
             return view.UpdateAsync(cancellationToken);

--- a/nhitomi/Interactivity/InteractiveManager.cs
+++ b/nhitomi/Interactivity/InteractiveManager.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Discord;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using nhitomi.Discord;
 using nhitomi.Interactivity.Triggers;
 
@@ -15,14 +14,10 @@ namespace nhitomi.Interactivity
     public class InteractiveManager : IReactionHandler
     {
         readonly IServiceProvider _services;
-        readonly DiscordService _discord;
-        readonly ILogger<InteractiveManager> _logger;
 
-        public InteractiveManager(IServiceProvider services, DiscordService discord, ILogger<InteractiveManager> logger)
+        public InteractiveManager(IServiceProvider services)
         {
             _services = services;
-            _discord = discord;
-            _logger = logger;
         }
 
         public readonly ConcurrentDictionary<ulong, IInteractiveMessage> InteractiveMessages =

--- a/nhitomi/Interactivity/InteractiveManager.cs
+++ b/nhitomi/Interactivity/InteractiveManager.cs
@@ -29,7 +29,7 @@ namespace nhitomi.Interactivity
             new ConcurrentDictionary<ulong, IInteractiveMessage>();
 
         public async Task SendInteractiveAsync(IEmbedMessage message, IDiscordContext context,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default, bool forceStateful = true)
         {
             // create dependency scope to initialize the interactive within
             using (var scope = _services.CreateScope())
@@ -46,10 +46,12 @@ namespace nhitomi.Interactivity
 
             var id = message.Message.Id;
 
-            // add to interactive list if we have stateful triggers
-            if (message is IInteractiveMessage interactiveMessage &&
-                interactiveMessage.Triggers.Values.Any(t => !t.CanRunStateless))
-                InteractiveMessages[id] = interactiveMessage;
+            if (message is IInteractiveMessage interactiveMessage)
+            {
+                // add to interactive list if we have stateful triggers
+                if (forceStateful || interactiveMessage.Triggers.Values.Any(t => !t.CanRunStateless))
+                    InteractiveMessages[id] = interactiveMessage;
+            }
 
             // forget interactives in an hour
             _ = Task.Run(async () =>

--- a/nhitomi/Interactivity/Triggers/DeleteTrigger.cs
+++ b/nhitomi/Interactivity/Triggers/DeleteTrigger.cs
@@ -23,6 +23,9 @@ namespace nhitomi.Interactivity.Triggers
             {
                 try
                 {
+                    if (Interactive != null && Interactive.Source?.Id != Context.User.Id)
+                        return false;
+
                     // remove from interactive list
                     _interactive.InteractiveMessages.TryRemove(Context.Message.Id, out _);
 

--- a/nhitomi/Interactivity/Triggers/DownloadTrigger.cs
+++ b/nhitomi/Interactivity/Triggers/DownloadTrigger.cs
@@ -25,10 +25,8 @@ namespace nhitomi.Interactivity.Triggers
 
             public override async Task<bool> RunAsync(CancellationToken cancellationToken = default)
             {
-                if (!await base.RunAsync(cancellationToken))
-                    return false;
-
-                if (!DoujinMessage.TryParseDoujinIdFromMessage(Context.Message, out var id, out var isFeed))
+                if (!await base.RunAsync(cancellationToken) ||
+                    !DoujinMessage.TryParseDoujinIdFromMessage(Context.Message, out var id, out var isFeed))
                     return false;
 
                 var doujin = await _database.GetDoujinAsync(id.source, id.id, cancellationToken);
@@ -38,7 +36,7 @@ namespace nhitomi.Interactivity.Triggers
 
                 var context = Context as IDiscordContext;
 
-                if (isFeed)
+                if (isFeed || Interactive?.Source?.Id != Context.User.Id)
                 {
                     // reply in DM if feed message
                     context = new DiscordContextWrapper(context)

--- a/nhitomi/Interactivity/Triggers/FavoriteTrigger.cs
+++ b/nhitomi/Interactivity/Triggers/FavoriteTrigger.cs
@@ -82,11 +82,16 @@ namespace nhitomi.Interactivity.Triggers
                 }
                 while (!await _database.SaveAsync(cancellationToken));
 
-                // reply in DM
-                var context = new DiscordContextWrapper(Context)
+                var context = Context as IDiscordContext;
+
+                if (isFeed || Interactive?.Source?.Id != Context.User.Id)
                 {
-                    Channel = await Context.User.GetOrCreateDMChannelAsync()
-                };
+                    // reply in DM if feed message
+                    context = new DiscordContextWrapper(Context)
+                    {
+                        Channel = await Context.User.GetOrCreateDMChannelAsync()
+                    };
+                }
 
                 if (added)
                     await context.ReplyAsync("addedToCollection", new {doujin, collection});

--- a/nhitomi/Interactivity/Triggers/ListJumpTrigger.cs
+++ b/nhitomi/Interactivity/Triggers/ListJumpTrigger.cs
@@ -54,7 +54,7 @@ namespace nhitomi.Interactivity.Triggers
 
             public override async Task<bool> RunAsync(CancellationToken cancellationToken = default)
             {
-                if (!await base.RunAsync(cancellationToken))
+                if (!await base.RunAsync(cancellationToken) || Interactive.Source?.Id != Context.User.Id)
                     return false;
 
                 switch (Trigger._destination)

--- a/nhitomi/Interactivity/Triggers/ListTrigger.cs
+++ b/nhitomi/Interactivity/Triggers/ListTrigger.cs
@@ -52,7 +52,7 @@ namespace nhitomi.Interactivity.Triggers
 
             public override async Task<bool> RunAsync(CancellationToken cancellationToken = default)
             {
-                if (!await base.RunAsync(cancellationToken))
+                if (!await base.RunAsync(cancellationToken) || Interactive.Source?.Id != Context.User.Id)
                     return false;
 
                 switch (Trigger._direction)

--- a/nhitomi/Interactivity/Triggers/ReadTrigger.cs
+++ b/nhitomi/Interactivity/Triggers/ReadTrigger.cs
@@ -25,10 +25,8 @@ namespace nhitomi.Interactivity.Triggers
 
             public override async Task<bool> RunAsync(CancellationToken cancellationToken = default)
             {
-                if (!await base.RunAsync(cancellationToken))
-                    return false;
-
-                if (!DoujinMessage.TryParseDoujinIdFromMessage(Context.Message, out var id, out var isFeed))
+                if (!await base.RunAsync(cancellationToken) ||
+                    !DoujinMessage.TryParseDoujinIdFromMessage(Context.Message, out var id, out var isFeed))
                     return false;
 
                 var doujin = await _database.GetDoujinAsync(id.source, id.id, cancellationToken);
@@ -38,7 +36,7 @@ namespace nhitomi.Interactivity.Triggers
 
                 var context = Context as IDiscordContext;
 
-                if (isFeed)
+                if (isFeed || Interactive?.Source?.Id != Context.User.Id)
                 {
                     // reply in DM if feed message
                     context = new DiscordContextWrapper(context)


### PR DESCRIPTION
Resolves #19 

- Triggers will reply in the same channel as the interactive if the reactor is the command author.
- Triggers will reply in a new DM if the reactor is different from the command author.
- Interactives can only be deleted by the command author, when it is still stateful.
- Interactives can be deleted by anyone after being forgotten (stateless).