### PR TITLE
Fix source contractions not working for doujin command overloads with two arguments

### DIFF
--- a/nhitomi/GalleryUtility.cs
+++ b/nhitomi/GalleryUtility.cs
@@ -40,5 +40,15 @@ namespace nhitomi
             return groups.Select(g => (g.Name.Split('_', 2)[1], g.Value))
                          .ToArray();
         }
+
+        public static string ExpandContraction(string source)
+        {
+            switch (source.Trim().ToLowerInvariant())
+            {
+                case "nh": return "nhentai";
+                case "hi": return "hitomi";
+                default:   return source;
+            }
+        }
     }
 }

--- a/nhitomi/Modules/CollectionModule.cs
+++ b/nhitomi/Modules/CollectionModule.cs
@@ -104,7 +104,9 @@ namespace nhitomi.Modules
                     _database.Add(collection);
                 }
 
-                doujin = await _database.GetDoujinAsync(source, id, cancellationToken);
+                doujin = await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source),
+                                                        id,
+                                                        cancellationToken);
 
                 if (doujin == null)
                 {
@@ -173,7 +175,9 @@ namespace nhitomi.Modules
                     return;
                 }
 
-                doujin = await _database.GetDoujinAsync(source, id, cancellationToken);
+                doujin = await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source),
+                                                        id,
+                                                        cancellationToken);
 
                 if (doujin == null)
                 {

--- a/nhitomi/Modules/DoujinModule.cs
+++ b/nhitomi/Modules/DoujinModule.cs
@@ -32,7 +32,8 @@ namespace nhitomi.Modules
                                    string id,
                                    CancellationToken cancellationToken = default)
         {
-            var doujin = await _database.GetDoujinAsync(source, id, cancellationToken);
+            var doujin =
+                await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source), id, cancellationToken);
 
             if (doujin == null)
             {
@@ -103,7 +104,7 @@ namespace nhitomi.Modules
                 {
                     Query         = query,
                     QualityFilter = false,
-                    Source        = source
+                    Source        = GalleryUtility.ExpandContraction(source)
                 }),
                 _context,
                 cancellationToken);
@@ -131,7 +132,8 @@ namespace nhitomi.Modules
                                         string id,
                                         CancellationToken cancellationToken = default)
         {
-            var doujin = await _database.GetDoujinAsync(source, id, cancellationToken);
+            var doujin =
+                await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source), id, cancellationToken);
 
             if (doujin == null)
             {
@@ -168,7 +170,8 @@ namespace nhitomi.Modules
                                     string id,
                                     CancellationToken cancellationToken = default)
         {
-            var doujin = await _database.GetDoujinAsync(source, id, cancellationToken);
+            var doujin =
+                await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source), id, cancellationToken);
 
             if (doujin == null)
             {

--- a/nhitomi/Modules/DoujinModule.cs
+++ b/nhitomi/Modules/DoujinModule.cs
@@ -32,8 +32,9 @@ namespace nhitomi.Modules
                                    string id,
                                    CancellationToken cancellationToken = default)
         {
-            var doujin =
-                await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source), id, cancellationToken);
+            var doujin = await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source),
+                                                        id,
+                                                        cancellationToken);
 
             if (doujin == null)
             {
@@ -132,8 +133,9 @@ namespace nhitomi.Modules
                                         string id,
                                         CancellationToken cancellationToken = default)
         {
-            var doujin =
-                await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source), id, cancellationToken);
+            var doujin = await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source),
+                                                        id,
+                                                        cancellationToken);
 
             if (doujin == null)
             {
@@ -170,8 +172,9 @@ namespace nhitomi.Modules
                                     string id,
                                     CancellationToken cancellationToken = default)
         {
-            var doujin =
-                await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source), id, cancellationToken);
+            var doujin = await _database.GetDoujinAsync(GalleryUtility.ExpandContraction(source),
+                                                        id,
+                                                        cancellationToken);
 
             if (doujin == null)
             {


### PR DESCRIPTION
`n!get nh/1234` was working but `n!get nh 1234` wasn't