### PR TITLE
Fix interactive stutters

### DIFF
--- a/nhitomi/Discord/ReactionHandlerService.cs
+++ b/nhitomi/Discord/ReactionHandlerService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -114,6 +115,8 @@ namespace nhitomi.Discord
                         Event         = eventType
                     };
 
+                    await ThrottleReactionUser(context);
+
                     try
                     {
                         foreach (var handler in _reactionHandlers)
@@ -148,6 +151,35 @@ namespace nhitomi.Discord
 
             public IReaction Reaction { get; set; }
             public ReactionEvent Event { get; set; }
+        }
+
+        // stores next reaction time
+        readonly ConcurrentDictionary<ulong, DateTime> _userReactionTimes = new ConcurrentDictionary<ulong, DateTime>();
+
+        // this is a workaround for Discord 5/5 rate limit that makes everything look smoother
+        // by throttling manually rather than sending requests in bursts of 5
+        async Task ThrottleReactionUser(IDiscordContext context)
+        {
+            var time = DateTime.Now;
+
+            // add current time or increment last value by 1 second
+            var nextReactionTime = _userReactionTimes.AddOrUpdate(
+                context.User.Id,
+                time,
+                (_,
+                 t) =>
+                {
+                    t = t.AddSeconds(1);
+
+                    if (t < time)
+                        t = time;
+
+                    return t;
+                });
+
+            // wait until next reaction time
+            if (nextReactionTime > time)
+                await Task.Delay(nextReactionTime - time);
         }
     }
 }

--- a/nhitomi/Discord/ReactionHandlerService.cs
+++ b/nhitomi/Discord/ReactionHandlerService.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -115,7 +115,8 @@ namespace nhitomi.Discord
                         Event         = eventType
                     };
 
-                    await ThrottleReactionUser(context);
+                    if (!await ThrottleReactionUser(context))
+                        return;
 
                     try
                     {
@@ -154,32 +155,44 @@ namespace nhitomi.Discord
         }
 
         // stores next reaction time
-        readonly ConcurrentDictionary<ulong, DateTime> _userReactionTimes = new ConcurrentDictionary<ulong, DateTime>();
+        readonly Dictionary<ulong, DateTime> _userReactionTimes = new Dictionary<ulong, DateTime>();
 
         // this is a workaround for Discord 5/5 rate limit that makes everything look smoother
         // by throttling manually rather than sending requests in bursts of 5
-        async Task ThrottleReactionUser(IDiscordContext context)
+        async Task<bool> ThrottleReactionUser(IDiscordContext context)
         {
-            var time = DateTime.Now;
+            DateTime currentTime;
+            DateTime nextReactionTime;
 
-            // add current time or increment last value by 1 second
-            var nextReactionTime = _userReactionTimes.AddOrUpdate(
-                context.User.Id,
-                time,
-                (_,
-                 t) =>
+            lock (_userReactionTimes)
+            {
+                currentTime = DateTime.Now;
+
+                if (_userReactionTimes.TryGetValue(context.User.Id, out nextReactionTime))
                 {
-                    t = t.AddSeconds(1);
+                    // increment last value by 1 second
+                    nextReactionTime = nextReactionTime.AddSeconds(1);
 
-                    if (t < time)
-                        t = time;
+                    if (nextReactionTime < currentTime)
+                        nextReactionTime = currentTime;
 
-                    return t;
-                });
+                    // ignore this reaction if reacting too fast
+                    else if (nextReactionTime > currentTime.AddSeconds(2))
+                        return false;
+                }
+                else
+                {
+                    nextReactionTime = currentTime;
+                }
+
+                _userReactionTimes[context.User.Id] = nextReactionTime;
+            }
 
             // wait until next reaction time
-            if (nextReactionTime > time)
-                await Task.Delay(nextReactionTime - time);
+            if (nextReactionTime > currentTime)
+                await Task.Delay(nextReactionTime - currentTime);
+
+            return true;
         }
     }
 }

--- a/nhitomi/Interactivity/EmbedMessage.cs
+++ b/nhitomi/Interactivity/EmbedMessage.cs
@@ -52,28 +52,32 @@ namespace nhitomi.Interactivity
 
             public abstract Task<bool> UpdateAsync(CancellationToken cancellationToken = default);
 
-            protected async Task SetMessageAsync(string localizationKey,
-                                                 object args = null,
-                                                 CancellationToken cancellationToken = default)
+            protected Task SetMessageAsync(string localizationKey,
+                                           object args = null,
+                                           CancellationToken cancellationToken = default)
             {
-                string l = Context.GetLocalization()[localizationKey, args];
+                string content = Context.GetLocalization()[localizationKey, args];
 
-                if (Message.Message == null)
-                    Message.Message = await Context.Channel.SendMessageAsync(l);
-                else
-                    await Message.Message.ModifyAsync(m => m.Content = l);
+                return SetViewAsync((Optional<string>) content, Optional<Embed>.Unspecified, cancellationToken);
             }
 
-            protected async Task SetEmbedAsync(Embed embed,
-                                               CancellationToken cancellationToken = default)
+            protected Task SetEmbedAsync(Embed embed,
+                                         CancellationToken cancellationToken = default) =>
+                SetViewAsync(null, embed, cancellationToken);
+
+            protected virtual async Task SetViewAsync(Optional<string> message,
+                                                      Optional<Embed> embed,
+                                                      CancellationToken cancellationToken = default)
             {
                 if (Message.Message == null)
-                    Message.Message = await Context.Channel.SendMessageAsync(embed: embed);
+                    Message.Message = await Context.Channel.SendMessageAsync(message.GetValueOrDefault(),
+                                                                             false,
+                                                                             embed.GetValueOrDefault());
                 else
                     await Message.Message.ModifyAsync(m =>
                     {
+                        m.Content = message;
                         m.Embed   = embed;
-                        m.Content = null;
                     });
             }
         }

--- a/nhitomi/Interactivity/InteractiveMessage.cs
+++ b/nhitomi/Interactivity/InteractiveMessage.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Discord;
 using Microsoft.Extensions.DependencyInjection;
+using nhitomi.Discord;
 using nhitomi.Interactivity.Triggers;
 
 namespace nhitomi.Interactivity
@@ -17,11 +18,11 @@ namespace nhitomi.Interactivity
     public abstract class InteractiveMessage<TView> : EmbedMessage<TView>, IInteractiveMessage
         where TView : EmbedMessage<TView>.ViewBase
     {
-        readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
-
         public IReadOnlyDictionary<IEmote, IReactionTrigger> Triggers { get; private set; }
 
         protected abstract IEnumerable<IReactionTrigger> CreateTriggers();
+
+        readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
 
         public override async Task<bool> UpdateViewAsync(IServiceProvider services,
                                                          CancellationToken cancellationToken = default)
@@ -65,6 +66,96 @@ namespace nhitomi.Interactivity
                     // message was deleted
                 }
             }
+        }
+
+        readonly Queue<InteractiveViewState> _pendingStates = new Queue<InteractiveViewState>();
+
+        struct InteractiveViewState
+        {
+            public IDiscordContext Context;
+            public Optional<string> Message;
+            public Optional<Embed> Embed;
+
+            public InteractiveViewState(IDiscordContext context,
+                                        Optional<string> message,
+                                        Optional<Embed> embed)
+            {
+                Context = context;
+                Message = message;
+                Embed   = embed;
+            }
+        }
+
+        DateTime _lastUpdateTime;
+
+        protected override async Task UpdateMessageAsync(IDiscordContext context,
+                                                         Optional<string> message,
+                                                         Optional<Embed> embed,
+                                                         CancellationToken cancellationToken = default)
+        {
+            var currentTime = DateTime.Now;
+
+            // always queue state if other states are pending
+            lock (_pendingStates)
+            {
+                if (_pendingStates.Count > 0)
+                {
+                    _pendingStates.Enqueue(new InteractiveViewState(context, message, embed));
+
+                    return;
+                }
+            }
+
+            var timeSinceLastUpdate = currentTime - _lastUpdateTime;
+
+            // if updating quickly (more than once per second)
+            if (timeSinceLastUpdate < TimeSpan.FromSeconds(1))
+            {
+                // queue state to update in the background
+                lock (_pendingStates)
+                    _pendingStates.Enqueue(new InteractiveViewState(context, message, embed));
+
+                // ReSharper disable once RedundantArgumentDefaultValue
+                _ = Task.Run(() => UpdateStateAsync(timeSinceLastUpdate, default), cancellationToken);
+            }
+
+            // otherwise update immediately
+            else
+            {
+                await base.UpdateMessageAsync(context, message, embed, cancellationToken);
+            }
+
+            _lastUpdateTime = currentTime;
+        }
+
+        async Task UpdateStateAsync(TimeSpan initialDelay,
+                                    CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(initialDelay, cancellationToken);
+
+            var state = new InteractiveViewState(null,
+                                                 Optional<string>.Unspecified,
+                                                 Optional<Embed>.Unspecified);
+
+            lock (_pendingStates)
+            {
+                if (_pendingStates.Count == 0)
+                    return;
+
+                // merge pending states into one
+                while (_pendingStates.TryDequeue(out var s))
+                {
+                    state.Context = s.Context;
+
+                    if (s.Message.IsSpecified)
+                        state.Message = s.Message;
+
+                    if (s.Embed.IsSpecified)
+                        state.Embed = s.Embed;
+                }
+            }
+
+            await base.UpdateMessageAsync(state.Context, state.Message, state.Embed, cancellationToken);
         }
 
         public virtual void Dispose() => _semaphore.Dispose();

--- a/nhitomi/Interactivity/InteractiveMessage.cs
+++ b/nhitomi/Interactivity/InteractiveMessage.cs
@@ -128,9 +128,6 @@ namespace nhitomi.Interactivity
 
             lock (_pendingStates)
             {
-                if (_pendingStates.Count == 0)
-                    return;
-
                 // merge pending states into one
                 while (_pendingStates.TryDequeue(out var s))
                 {

--- a/nhitomi/Interactivity/InteractiveMessage.cs
+++ b/nhitomi/Interactivity/InteractiveMessage.cs
@@ -96,7 +96,7 @@ namespace nhitomi.Interactivity
             var currentTime = DateTime.Now;
             var timeToWait  = _lastUpdateTime + TimeSpan.FromSeconds(1) - currentTime;
 
-            // if updating quickly (more than once per second)
+            // if updating too quickly
             if (timeToWait.Ticks > 0)
                 lock (_pendingStates)
                 {


### PR DESCRIPTION
Resolves #18 

When the user changes the interactive too quickly, `InteractiveMessage` will automatically save its state to a queue, merge them into one and update the message as a single request with throttling in the middle.