### PR TITLE
Huge performance improvements to book indexer

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -70,12 +70,6 @@
     }
   },
   "web": {
-    "api": {
-      "connectionFailed": {
-        "title": "Connection failed",
-        "description": "Could not connect to nhitomi. We will automatically try again."
-      }
-    },
     "notification": {
       "error": {
         "unknownReason": "Unknown reason."

--- a/nhitomi-idx/nhitomi/Database/DbBookImage.cs
+++ b/nhitomi-idx/nhitomi/Database/DbBookImage.cs
@@ -1,3 +1,4 @@
+using System;
 using MessagePack;
 using Nest;
 using nhitomi.Models;
@@ -17,7 +18,7 @@ namespace nhitomi.Database
         {
             base.MapTo(model);
 
-            model.Notes = Notes?.ToArray(n => n.Convert());
+            model.Notes = Notes?.ToArray(n => n.Convert()) ?? Array.Empty<ImageNote>();
         }
 
         public override void MapFrom(BookImage model)

--- a/nhitomi-idx/nhitomi/Database/ElasticClient.cs
+++ b/nhitomi-idx/nhitomi/Database/ElasticClient.cs
@@ -265,7 +265,7 @@ namespace nhitomi.Database
         /// This method is useful when creating a new object in the database.
         /// Operations on the object will bypass concurrency checks because concurrency information had not been loaded (hence it is not recommended).
         /// </remarks>
-        IDbEntry<T> Entry<T>(T value) where T : class, IDbObject => Entry<T>(value.Id ?? Snowflake.New).Chain(x => x.Value = value);
+        IDbEntry<T> Entry<T>(T value) where T : class, IDbObject;
 
         /// <summary>
         /// Retrieves an object from the database.
@@ -289,6 +289,11 @@ namespace nhitomi.Database
         /// Retrieves multiple objects from the database and wraps them in <see cref="IDbEntry{T}"/>.
         /// </summary>
         Task<IDbEntry<T>[]> GetEntryManyAsync<T>(string[] ids, CancellationToken cancellationToken = default) where T : class, IDbObject => Task.WhenAll(ids.Select(id => GetEntryAsync<T>(id, cancellationToken)));
+
+        /// <summary>
+        /// Indexes many objects in bulk.
+        /// </summary>
+        Task<IDbEntry<T>[]> IndexManyAsync<T>(T[] values, OpType type, CancellationToken cancellationToken = default) where T : class, IDbObject => Task.WhenAll(values.Select(v => Entry(v).Chain(x => x.CreateAsync(cancellationToken))));
 
         /// <summary>
         /// Searches for objects from the database.
@@ -332,9 +337,9 @@ namespace nhitomi.Database
         readonly IOptionsMonitor<ElasticOptions> _options;
         readonly IRedisClient _redis;
         readonly IResourceLocker _locker;
-        readonly ILogger<Nest.ElasticClient> _logger;
+        readonly ILogger<ElasticClient> _logger;
 
-        public ElasticClient(IOptionsMonitor<ElasticOptions> options, IRedisClient redis, IResourceLocker locker, ILogger<Nest.ElasticClient> logger)
+        public ElasticClient(IOptionsMonitor<ElasticOptions> options, IRedisClient redis, IResourceLocker locker, ILogger<ElasticClient> logger)
         {
             var opts = options.CurrentValue;
 
@@ -369,8 +374,9 @@ namespace nhitomi.Database
             {
                 var options = new IndexingOptions();
 
-                foreach (var opts in _indexingOptions.Value)
-                    opts.MergeInto(options);
+                if (_indexingOptions.Value != null)
+                    foreach (var opts in _indexingOptions.Value)
+                        opts.MergeInto(options);
 
                 return options;
             }
@@ -524,6 +530,7 @@ namespace nhitomi.Database
 #endregion
 
         public IDbEntry<T> Entry<T>(string id) where T : class, IDbObject => new EntryWrapper<T>(this, id);
+        public IDbEntry<T> Entry<T>(T value) where T : class, IDbObject => Entry<T>(value.Id ?? Snowflake.New).Chain(x => x.Value = value);
 
         /// <summary>
         /// Serializable entry object for storing in cache.
@@ -547,7 +554,7 @@ namespace nhitomi.Database
         sealed class EntryWrapper<T> : IDbEntry<T> where T : class, IDbObject
         {
             readonly ElasticClient _client;
-            readonly ILogger<Nest.ElasticClient> _logger;
+            readonly ILogger<ElasticClient> _logger;
             readonly IRedisClient _redis;
 
             public string Id { get; }
@@ -577,7 +584,7 @@ namespace nhitomi.Database
                 Id = id;
 
                 if (info != null)
-                    Refresh(info);
+                    SetInfo(info);
             }
 
 #region Index
@@ -588,29 +595,32 @@ namespace nhitomi.Database
             public Task<T> UpdateAsync(CancellationToken cancellationToken = default)
                 => IndexAsyncInternal(OpType.Index, cancellationToken);
 
-            async Task<T> IndexAsyncInternal(OpType type, CancellationToken cancellationToken = default)
+            internal void PrepareIndexInternal()
             {
-                if (Value == null)
+                if (_value == null)
                     throw new InvalidOperationException($"Cannot create or update entry when {nameof(Value)} is null.");
 
+                var now = DateTime.UtcNow;
+
+                if (_value is IHasCreatedTime hasCreatedTime && hasCreatedTime.CreatedTime == default)
+                    hasCreatedTime.CreatedTime = now;
+
+                if (_value is IHasUpdatedTime hasUpdatedTime)
+                    hasUpdatedTime.UpdatedTime = now;
+
+                _value.UpdateCache();
+            }
+
+            async Task<T> IndexAsyncInternal(OpType type, CancellationToken cancellationToken = default)
+            {
                 var measure  = new MeasureContext();
                 var options  = _client._options.CurrentValue;
                 var options2 = _client.CurrentIndexingOptions;
 
+                PrepareIndexInternal();
+
                 var index = await _client.GetIndexAsync<T>(cancellationToken);
 
-                // set created time
-                if (_value is IHasCreatedTime hasCreatedTime && hasCreatedTime.CreatedTime == default)
-                    hasCreatedTime.CreatedTime = DateTime.UtcNow;
-
-                // set updated time
-                if (_value is IHasUpdatedTime hasUpdatedTime)
-                    hasUpdatedTime.UpdatedTime = DateTime.UtcNow;
-
-                // update cached properties
-                _value.UpdateCache();
-
-                // index request
                 IIndexRequest<T> selector(IndexDescriptor<T> x)
                 {
                     x = x.Index(index.IndexName)
@@ -630,7 +640,6 @@ namespace nhitomi.Database
                 if (_logger.IsEnabled(LogLevel.Debug))
                     _logger.LogDebug($"{(type == OpType.Index ? "Indexed" : "Created")} {index} {Id} in {measure}: {SerializeValue(Value)}");
 
-                // update info
                 var info = new EntryInfo<T>
                 {
                     Value          = _value,
@@ -638,7 +647,7 @@ namespace nhitomi.Database
                     PrimaryTerm    = response.PrimaryTerm
                 };
 
-                Refresh(info);
+                SetInfo(info);
 
                 // update cache
                 await _redis.SetObjectAsync(index.CachePrefix + Id, info, index.CacheExpiry, cancellationToken: cancellationToken);
@@ -658,7 +667,6 @@ namespace nhitomi.Database
 
                 var index = await _client.GetIndexAsync<T>(cancellationToken);
 
-                // delete request
                 IDeleteRequest selector(DeleteDescriptor<T> x)
                     => x.Index(index.IndexName)
                         .IfSequenceNumber(_sequenceNumber)
@@ -670,15 +678,14 @@ namespace nhitomi.Database
                 if (_logger.IsEnabled(LogLevel.Debug))
                     _logger.LogDebug($"Deleted {index} {Id} in {measure}: {SerializeValue(Value)}");
 
-                // update info
                 var info = new EntryInfo<T>
                 {
-                    Value          = _value = default,
+                    Value          = default,
                     SequenceNumber = response.SequenceNumber,
                     PrimaryTerm    = response.PrimaryTerm
                 };
 
-                Refresh(info);
+                SetInfo(info);
 
                 // update cache
                 await _redis.SetObjectAsync(index.CachePrefix + Id, info, index.CacheExpiry, cancellationToken: cancellationToken);
@@ -692,10 +699,10 @@ namespace nhitomi.Database
             {
                 var index = await _client.GetIndexAsync<T>(cancellationToken);
 
-                // update info with fresh values
+                // set info with fresh value
                 var info = await _client.GetDirectAsync<T>(Id, cancellationToken);
 
-                Refresh(info);
+                SetInfo(info);
 
                 // update cache
                 await _redis.SetObjectAsync(index.CachePrefix + Id, info, index.CacheExpiry, cancellationToken: cancellationToken);
@@ -703,7 +710,7 @@ namespace nhitomi.Database
                 return _value;
             }
 
-            void Refresh(EntryInfo<T> info)
+            internal void SetInfo(EntryInfo<T> info)
             {
                 _value          = info.Value;
                 _sequenceNumber = info.SequenceNumber;
@@ -735,7 +742,7 @@ namespace nhitomi.Database
         public async Task<IDbEntry<T>> GetEntryAsync<T>(string id, CancellationToken cancellationToken = default) where T : class, IDbObject
         {
             if (string.IsNullOrEmpty(id))
-                return Entry<T>(null);
+                return Entry<T>(id);
 
             var index = await GetIndexAsync<T>(cancellationToken);
 
@@ -761,7 +768,7 @@ namespace nhitomi.Database
         {
             var index = await GetIndexAsync<T>(cancellationToken);
 
-            var response = await Request(c => c.MultiGetAsync(x => x.Index(index.IndexName).GetMany<T>(ids), cancellationToken));
+            var response = await Request(c => c.MultiGetAsync(x => x.Index(index.IndexName).GetMany<T>(ids).Realtime(), cancellationToken));
 
             var indexes = new Dictionary<string, int>(ids.Length);
 
@@ -794,7 +801,7 @@ namespace nhitomi.Database
             if (ids == null || ids.Length == 0)
                 return Array.Empty<IDbEntry<T>>();
 
-            if (ids.Length == 0)
+            if (ids.Length == 1)
                 return new[] { await GetEntryAsync<T>(ids[0], cancellationToken) };
 
             var index = await GetIndexAsync<T>(cancellationToken);
@@ -846,6 +853,95 @@ namespace nhitomi.Database
                 entries[i] = new EntryWrapper<T>(this, ids[i], infos[i]);
 
             return entries;
+        }
+
+#endregion
+
+#region Create (bulk)
+
+        public async Task<IDbEntry<T>[]> IndexManyAsync<T>(T[] values, OpType type, CancellationToken cancellationToken = default) where T : class, IDbObject
+        {
+            if (values == null || values.Length == 0)
+                return Array.Empty<IDbEntry<T>>();
+
+            if (values.Length == 1)
+                return new[] { await Entry(values[0]).Chain(x => x.CreateAsync(cancellationToken)) };
+
+            var measure  = new MeasureContext();
+            var options  = _options.CurrentValue;
+            var options2 = CurrentIndexingOptions;
+
+            var entries = new EntryWrapper<T>[values.Length];
+            var results = new IDbEntry<T>[entries.Length]; // co-variant conversion
+            var indexes = new Dictionary<string, int>(entries.Length);
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                var entry = (EntryWrapper<T>) Entry(values[i]);
+
+                entries[i] = entry;
+                results[i] = entry;
+                entry.PrepareIndexInternal();
+
+                indexes[entry.Id] = i;
+            }
+
+            var index = await GetIndexAsync<T>(cancellationToken);
+
+            var response = await Request(c => c.BulkAsync(b =>
+            {
+                b = type switch
+                {
+                    OpType.Create => b.CreateMany(entries.Select(x => x.Value), (x, v) => x.Index(index.IndexName).Id(v.Id)),
+                    OpType.Index  => b.IndexMany(entries.Select(x => x.Value), (x, v) => x.Index(index.IndexName).Id(v.Id)),
+
+                    _ => throw new NotSupportedException(nameof(type))
+                };
+
+                return b.Refresh(options2.Refresh ?? options.RequestRefreshOption);
+            }, cancellationToken));
+
+            var infos     = new EntryInfo<T>[entries.Length];
+            var cacheKeys = new RedisKey[entries.Length];
+
+            foreach (var item in response.Items)
+            {
+                if (!indexes.Remove(item.Id, out var i))
+                    continue;
+
+                var entry = entries[i];
+
+                var info = new EntryInfo<T>
+                {
+                    Value          = entry.Value,
+                    SequenceNumber = item.SequenceNumber,
+                    PrimaryTerm    = item.PrimaryTerm
+                };
+
+                infos[i]     = info;
+                cacheKeys[i] = index.CachePrefix + entry.Id;
+
+                entry.SetInfo(info);
+
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug($"{(type == OpType.Index ? "Indexed" : "Created")} {index} {entry.Id} in {measure} (bulk): {SerializeValue(entry.Value)}");
+            }
+
+            foreach (var i in indexes.Values) // fill nulls with empty info
+            {
+                var entry = entries[i];
+                var info  = new EntryInfo<T>();
+
+                infos[i]     = info;
+                cacheKeys[i] = index.CachePrefix + entry.Id;
+
+                entry.SetInfo(info);
+            }
+
+            // update cache
+            await _redis.SetObjectManyAsync(cacheKeys, infos, index.CacheExpiry, cancellationToken: cancellationToken);
+
+            return results;
         }
 
 #endregion

--- a/nhitomi-idx/nhitomi/Discord/Commands/DatabaseModule.cs
+++ b/nhitomi-idx/nhitomi/Discord/Commands/DatabaseModule.cs
@@ -26,7 +26,7 @@ namespace nhitomi.Discord.Commands
         public async Task GetAsync([Remainder] string link)
         {
             // try book scrapers
-            var books = await _scrapers.Books.ToAsyncEnumerable().SelectMany(s => s.FindBookByUrlAsync(link, true)).Select(x => x.book.Value).ToArrayAsync();
+            var books = await _scrapers.Books.ToAsyncEnumerable().SelectMany(s => s.FindByUrlAsync(link, true)).Select(x => x.book.Value).ToArrayAsync();
 
             switch (books.Length)
             {
@@ -48,7 +48,7 @@ namespace nhitomi.Discord.Commands
         public async Task ViewAsync([Remainder] string link)
         {
             // try book scrapers
-            var (book, content) = await _scrapers.Books.ToAsyncEnumerable().SelectMany(s => s.FindBookByUrlAsync(link, true)).FirstOrDefaultAsync();
+            var (book, content) = await _scrapers.Books.ToAsyncEnumerable().SelectMany(s => s.FindByUrlAsync(link, true)).FirstOrDefaultAsync();
 
             if (book != null && content != null)
             {

--- a/nhitomi-idx/nhitomi/Extensions.cs
+++ b/nhitomi-idx/nhitomi/Extensions.cs
@@ -52,6 +52,27 @@ namespace nhitomi
 
     public static class Extensions
     {
+        sealed class DisposableStackContext<T> : IDisposable
+        {
+            readonly Stack<T> _stack;
+
+            public DisposableStackContext(Stack<T> stack)
+            {
+                _stack = stack;
+            }
+
+            public void Dispose() => _stack.Pop();
+        }
+
+        /// <summary>
+        /// Pushes an item to a stack and returns a disposable value that pops once when disposed.
+        /// </summary>
+        public static IDisposable PushContext<T>(this Stack<T> stack, T item)
+        {
+            stack.Push(item);
+            return new DisposableStackContext<T>(stack);
+        }
+
         sealed class DisposableSemaphoreReleaseContext : IDisposable
         {
             readonly SemaphoreSlim _semaphore;

--- a/nhitomi-idx/nhitomi/Models/Book.cs
+++ b/nhitomi-idx/nhitomi/Models/Book.cs
@@ -40,14 +40,14 @@ namespace nhitomi.Models
         /// <summary>
         /// Fully localized name of this book, which is usually in Japanese.
         /// </summary>
-        [Required, MinLength(3)]
+        [Required, MinLength(3), MaxLength(64)]
         public string PrimaryName { get; set; }
 
         /// <summary>
         /// Name of this book translated to English.
         /// This should be in plain comprehensible English, not a direct romanization of primary name.
         /// </summary>
-        [MinLength(3)]
+        [MinLength(3), MaxLength(64)]
         public string EnglishName { get; set; }
 
         /// <summary>

--- a/nhitomi-idx/nhitomi/Models/BookImage.cs
+++ b/nhitomi-idx/nhitomi/Models/BookImage.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace nhitomi.Models
 {
     /// <summary>
@@ -8,6 +10,7 @@ namespace nhitomi.Models
         /// <summary>
         /// Notes on this image.
         /// </summary>
+        [Required]
         public ImageNote[] Notes { get; set; }
     }
 }

--- a/nhitomi-idx/nhitomi/Models/Collection.cs
+++ b/nhitomi-idx/nhitomi/Models/Collection.cs
@@ -16,13 +16,13 @@ namespace nhitomi.Models
         public string Id { get; set; }
 
         /// <summary>
-        /// Time when this book was created.
+        /// Time when this collection was created.
         /// </summary>
         [Required]
         public DateTime CreatedTime { get; set; }
 
         /// <summary>
-        /// Time when this book was updated.
+        /// Time when this collection was updated.
         /// </summary>
         [Required]
         public DateTime UpdatedTime { get; set; }

--- a/nhitomi-idx/nhitomi/Models/Collection.cs
+++ b/nhitomi-idx/nhitomi/Models/Collection.cs
@@ -51,13 +51,13 @@ namespace nhitomi.Models
         /// <summary>
         /// Name of this collection.
         /// </summary>
-        [Required]
+        [Required, MinLength(1), MaxLength(64)]
         public string Name { get; set; }
 
         /// <summary>
         /// Text describing this collection.
         /// </summary>
-        [Required]
+        [Required, MaxLength(512)]
         public string Description { get; set; }
     }
 }

--- a/nhitomi-idx/nhitomi/Models/Image.cs
+++ b/nhitomi-idx/nhitomi/Models/Image.cs
@@ -52,6 +52,7 @@ namespace nhitomi.Models
         /// <summary>
         /// Source from where this image was downloaded.
         /// </summary>
+        [Required]
         public ScraperType Source { get; set; }
     }
 

--- a/nhitomi-idx/nhitomi/Models/ImageNote.cs
+++ b/nhitomi-idx/nhitomi/Models/ImageNote.cs
@@ -45,7 +45,7 @@ namespace nhitomi.Models
         /// <summary>
         /// Content text that supports markdown.
         /// </summary>
-        [Required, MinLength(5), MaxLength(1024)]
+        [Required, MinLength(5), MaxLength(256)]
         public string Content { get; set; }
     }
 }

--- a/nhitomi-idx/nhitomi/Scrapers/BookIndexer.cs
+++ b/nhitomi-idx/nhitomi/Scrapers/BookIndexer.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using Microsoft.Extensions.Logging;
+using Nest;
+using nhitomi.Database;
+using nhitomi.Models.Queries;
+using IElasticClient = nhitomi.Database.IElasticClient;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace nhitomi.Scrapers
+{
+    public interface IBookIndexer
+    {
+        Task IndexAsync(DbBook[] books, CancellationToken cancellationToken = default);
+    }
+
+    public class BookIndexer : IBookIndexer
+    {
+        readonly IElasticClient _client;
+        readonly IResourceLocker _locker;
+        readonly ILogger<BookIndexer> _logger;
+
+        public BookIndexer(IElasticClient client, IResourceLocker locker, ILogger<BookIndexer> logger)
+        {
+            _client = client;
+            _locker = locker;
+            _logger = logger;
+        }
+
+        public async Task IndexAsync(DbBook[] books, CancellationToken cancellationToken = default)
+        {
+            books = DryMerge(books);
+
+            // prevent concurrent book indexing to allow efficient merging
+            await using (await _locker.EnterAsync("index:book", cancellationToken))
+            {
+                // refresh immediately to speed up indexing
+                using (_client.UseIndexingOptions(new IndexingOptions { Refresh = Refresh.True }))
+                    await CreateAsync(await MergeAsync(books, cancellationToken), cancellationToken);
+            }
+        }
+
+        static string FormatBook(DbBook book)
+        {
+            var s = $"'{book.PrimaryName}' {string.Join(',', book.Contents.Select(c => $"{c.Source}/{c.SourceId}"))}";
+
+            if (book.Id != null)
+                s = $"{book.Id} {s}";
+
+            return s;
+        }
+
+        /// <summary>
+        /// Efficiently merges books in-memory without making search requests.
+        /// By deriving a unique list of books, we can reduce the number of database operations and, when possible, bulk create books that are not mergeable.
+        /// </summary>
+        DbBook[] DryMerge(DbBook[] books)
+        {
+            var measure = new MeasureContext();
+
+            var results      = new List<DbBook>(books.Length);
+            var primaryNames = new Dictionary<string, HashSet<DbBook>>(books.Length, StringComparer.OrdinalIgnoreCase);
+            var englishNames = new Dictionary<string, HashSet<DbBook>>(books.Length, StringComparer.OrdinalIgnoreCase);
+            var artistTags   = new Dictionary<string, HashSet<DbBook>>(StringComparer.OrdinalIgnoreCase);
+            var circleTags   = new Dictionary<string, HashSet<DbBook>>(StringComparer.OrdinalIgnoreCase);
+
+            static void union(HashSet<DbBook> set, Dictionary<string, HashSet<DbBook>> dict, string key)
+            {
+                if (string.IsNullOrEmpty(key)) return;
+
+                if (dict.TryGetValue(key, out var other))
+                    set.UnionWith(other);
+            }
+
+            static void index(DbBook book, Dictionary<string, HashSet<DbBook>> dict, string key)
+            {
+                if (string.IsNullOrEmpty(key)) return;
+
+                if (dict.TryGetValue(key, out var set))
+                    set.Add(book);
+                else
+                    dict[key] = new HashSet<DbBook> { book };
+            }
+
+            foreach (var book in books)
+            {
+                var set = new HashSet<DbBook>();
+
+                union(set, primaryNames, book.PrimaryName);
+                union(set, englishNames, book.EnglishName);
+
+                var acSet = new HashSet<DbBook>();
+
+                foreach (var artist in book.TagsArtist ?? Array.Empty<string>()) union(acSet, artistTags, artist);
+                foreach (var circle in book.TagsCircle ?? Array.Empty<string>()) union(acSet, circleTags, circle);
+
+                set.IntersectWith(acSet);
+
+                var merged = false;
+
+                foreach (var other in set)
+                {
+                    other.MergeFrom(book);
+
+                    if (_logger.IsEnabled(LogLevel.Information))
+                        _logger.LogInformation($"Merged book {FormatBook(book)} into similar book {FormatBook(other)} (dry).");
+
+                    merged = true;
+                    break;
+                }
+
+                // only add unique (not merged) books to results and indexes
+                if (!merged)
+                {
+                    results.Add(book);
+
+                    index(book, primaryNames, book.PrimaryName);
+                    index(book, englishNames, book.EnglishName);
+
+                    foreach (var artist in book.TagsArtist ?? Array.Empty<string>()) index(book, artistTags, artist);
+                    foreach (var circle in book.TagsCircle ?? Array.Empty<string>()) index(book, circleTags, circle);
+                }
+            }
+
+            _logger.LogDebug($"Dry merging {books.Length} -> {results.Count} books took {measure}.");
+
+            return results.ToArray();
+        }
+
+        // we consider two books to be the same if they have:
+        // - matching primary or english name
+        // - matching artist or circle
+        // - at least one matching character (todo: temporarily disabled 2020/04/29)
+        sealed class SimilarQuery : IQueryProcessor<DbBook>
+        {
+            readonly DbBook _book;
+
+            public SimilarQuery(DbBook book)
+            {
+                _book = book;
+            }
+
+            public SearchDescriptor<DbBook> Process(SearchDescriptor<DbBook> descriptor)
+                => descriptor.Take(1)
+                             .MultiQuery(q => q.SetMode(QueryMatchMode.All)
+                                               .Nested(qq => qq.SetMode(QueryMatchMode.Any)
+                                                               .Text($"\"{_book.PrimaryName}\"", b => b.PrimaryName) // quotes for phrase query
+                                                               .Text($"\"{_book.EnglishName}\"", b => b.EnglishName))
+                                               .Nested(qq => qq.SetMode(QueryMatchMode.Any)
+                                                               .Text(new TextQuery { Values = _book.TagsArtist?.ToArray(s => $"\"{s}\""), Mode = QueryMatchMode.Any }, b => b.TagsArtist)
+                                                               .Text(new TextQuery { Values = _book.TagsCircle?.ToArray(s => $"\"{s}\""), Mode = QueryMatchMode.Any }, b => b.TagsCircle)))
+                              //.Filter(new FilterQuery<string> { Values = _book.TagsCharacter, Mode = QueryMatchMode.Any }, b => b.TagsCharacter))
+                             .MultiSort(() => (SortDirection.Descending, null));
+        }
+
+        /// <summary>
+        /// Merges books with existing ones in the database, and returns remaining books that were not merged.
+        /// </summary>
+        async Task<DbBook[]> MergeAsync(DbBook[] books, CancellationToken cancellationToken = default)
+        {
+            var list = new List<DbBook>(books.Length);
+
+            foreach (var book in books)
+            {
+                if ((book.PrimaryName != null || book.EnglishName != null) &&
+                    (book.TagsArtist?.Length > 0 || book.TagsCircle?.Length > 0))
+                {
+                    var result = await _client.SearchEntriesAsync(new SimilarQuery(book), cancellationToken);
+                    var entry  = result.Items?.FirstOrDefault();
+
+                    do
+                    {
+                        if (entry?.Value == null)
+                            goto add;
+
+                        entry.Value.MergeFrom(book);
+                    }
+                    while (!await entry.TryUpdateAsync(cancellationToken));
+
+                    if (_logger.IsEnabled(LogLevel.Information))
+                        _logger.LogInformation($"Merged book {FormatBook(book)} into similar book {FormatBook(entry.Value)}.");
+
+                    continue;
+                }
+
+                add:
+                list.Add(book);
+
+                if (_logger.IsEnabled(LogLevel.Information))
+                    _logger.LogInformation($"Merge skipping for book {FormatBook(book)}.");
+            }
+
+            return list.ToArray();
+        }
+
+        Task CreateAsync(DbBook[] books, CancellationToken cancellationToken = default) => _client.IndexManyAsync(books, OpType.Index, cancellationToken);
+    }
+}

--- a/nhitomi-idx/nhitomi/Scrapers/nhentaiBook.cs
+++ b/nhitomi-idx/nhitomi/Scrapers/nhentaiBook.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using nhitomi.Models;
+
+namespace nhitomi.Scrapers
+{
+    public class nhentaiBook
+    {
+        [JsonProperty("id")] public int Id;
+        [JsonProperty("media_id")] public int MediaId;
+        [JsonProperty("upload_date")] public long UploadDate;
+        [JsonProperty("title")] public TitleData Title;
+        [JsonProperty("images")] public ImagesData Images;
+        [JsonProperty("tags")] public TagData[] Tags;
+
+        public class TitleData
+        {
+            [JsonProperty("japanese")] public string Japanese;
+            [JsonProperty("english")] public string English;
+        }
+
+        public class ImagesData
+        {
+            [JsonProperty("pages")] public ImageData[] Pages;
+
+            public class ImageData
+            {
+                [JsonProperty("t")] public char Type;
+            }
+        }
+
+        public class TagData
+        {
+            [JsonProperty("type")] public string Type;
+            [JsonProperty("name")] public string Name;
+        }
+    }
+
+    public class nhentaiList
+    {
+        [JsonProperty("result")] public nhentaiBook[] Results;
+        [JsonProperty("num_pages")] public int NumPages;
+        [JsonProperty("per_page")] public int PerPage;
+    }
+
+    public class nhentaiBookAdaptor : BookAdaptor
+    {
+        readonly nhentaiBook _book;
+
+        public nhentaiBookAdaptor(nhentaiBook book)
+        {
+            _book = book;
+        }
+
+        // regex to match any () and [] in titles
+        static readonly Regex _bracketsRegex = new Regex(@"\([^)]*\)|\[[^\]]*\]|（[^）]*）", RegexOptions.Compiled | RegexOptions.Singleline);
+
+        public static string FixTitle(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return null;
+
+            // replace stuff in brackets with nothing
+            s = _bracketsRegex.Replace(s, "").Trim();
+
+            // decode html-encoded strings
+            s = WebUtility.HtmlDecode(s);
+
+            s = s.Trim();
+
+            return string.IsNullOrEmpty(s) ? null : s;
+        }
+
+        // regex to match the convention in title (first parentheses)
+        static readonly Regex _conventionRegex = new Regex(@"^\((?<conv>.*?)\)", RegexOptions.Compiled | RegexOptions.Singleline);
+
+        public static string FindConvention(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return null;
+
+            return _conventionRegex.Match(s.TrimStart()).Groups["conv"].Value;
+        }
+
+        /// <summary>
+        /// Some books are incorrectly tagged with a pipe separator.
+        /// </summary>
+        public static IEnumerable<string> ProcessTag(nhentaiBook.TagData tag) => tag.Name.Split('|', StringSplitOptions.RemoveEmptyEntries);
+
+        public override BookBase Book => new BookBase
+        {
+            PrimaryName = FixTitle(_book.Title.Japanese) ?? FixTitle(_book.Title.English),
+            EnglishName = FixTitle(_book.Title.English) ?? FixTitle(_book.Title.Japanese),
+
+            Tags = new Dictionary<BookTag, string[]>
+            {
+                [BookTag.Artist]     = _book.Tags?.Where(t => t.Type == "artist").ToArrayMany(ProcessTag),
+                [BookTag.Tag]        = _book.Tags?.Where(t => t.Type == "tag").ToArrayMany(ProcessTag),
+                [BookTag.Parody]     = _book.Tags?.Where(t => t.Type == "parody" && t.Name != "original").ToArrayMany(ProcessTag),
+                [BookTag.Character]  = _book.Tags?.Where(t => t.Type == "character").ToArrayMany(ProcessTag),
+                [BookTag.Convention] = new[] { FindConvention(_book.Title.English ?? _book.Title.Japanese) },
+                [BookTag.Circle]     = _book.Tags?.Where(t => t.Type == "group").ToArrayMany(ProcessTag)
+            },
+
+            Category = Enum.TryParse<BookCategory>(_book.Tags?.FirstOrDefault(t => t.Type == "category")?.Name, true, out var category) ? category : BookCategory.Doujinshi,
+            Rating   = MaterialRating.Explicit, // explicit by default
+        };
+
+        public override IEnumerable<ContentAdaptor> Contents => new[] { new nhentaiContentAdaptor(_book) };
+    }
+
+    public class nhentaiContentAdaptor : BookAdaptor.ContentAdaptor
+    {
+        readonly nhentaiBook _book;
+
+        public nhentaiContentAdaptor(nhentaiBook book)
+        {
+            _book = book;
+        }
+
+        public override string Id => _book.Id.ToString();
+        public override int Pages => _book.Images.Pages.Length;
+
+        public override string Data => nhentaiScraper.DataContainer.Serialize(new nhentaiScraper.DataContainer
+        {
+            MediaId    = _book.MediaId,
+            Extensions = string.Concat(_book.Images.Pages.Select(p => p.Type))
+        });
+
+        public override BookContentBase Content => new BookContentBase
+        {
+            Language = _book.Tags?.FirstOrDefault(t => t.Type == "language" && t.Name != "translated")?.Name.ParseAsLanguage() ?? LanguageType.Japanese
+        };
+    }
+}

--- a/nhitomi-idx/nhitomi/Scrapers/nhentaiScraper.cs
+++ b/nhitomi-idx/nhitomi/Scrapers/nhentaiScraper.cs
@@ -5,149 +5,17 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using nhitomi.Database;
-using nhitomi.Models;
 using nhitomi.Scrapers.Tests;
 using nhitomi.Storage;
 
 namespace nhitomi.Scrapers
 {
-    public class nhentaiBook
-    {
-        [JsonProperty("id")] public int Id;
-        [JsonProperty("media_id")] public int MediaId;
-        [JsonProperty("upload_date")] public long UploadDate;
-        [JsonProperty("title")] public TitleData Title;
-        [JsonProperty("images")] public ImagesData Images;
-        [JsonProperty("tags")] public TagData[] Tags;
-
-        public class TitleData
-        {
-            [JsonProperty("japanese")] public string Japanese;
-            [JsonProperty("english")] public string English;
-        }
-
-        public class ImagesData
-        {
-            [JsonProperty("pages")] public ImageData[] Pages;
-
-            public class ImageData
-            {
-                [JsonProperty("t")] public char Type;
-            }
-        }
-
-        public class TagData
-        {
-            [JsonProperty("type")] public string Type;
-            [JsonProperty("name")] public string Name;
-        }
-    }
-
-    public class nhentaiList
-    {
-        [JsonProperty("result")] public nhentaiBook[] Results;
-        [JsonProperty("num_pages")] public int NumPages;
-        [JsonProperty("per_page")] public int PerPage;
-    }
-
-    public class nhentaiBookAdaptor : BookAdaptor
-    {
-        readonly nhentaiBook _book;
-
-        public nhentaiBookAdaptor(nhentaiBook book)
-        {
-            _book = book;
-        }
-
-        // regex to match any () and [] in titles
-        static readonly Regex _bracketsRegex = new Regex(@"\([^)]*\)|\[[^\]]*\]|（[^）]*）", RegexOptions.Compiled | RegexOptions.Singleline);
-
-        public static string FixTitle(string s)
-        {
-            if (string.IsNullOrEmpty(s))
-                return null;
-
-            // replace stuff in brackets with nothing
-            s = _bracketsRegex.Replace(s, "").Trim();
-
-            // decode html-encoded strings
-            s = HttpUtility.HtmlDecode(s);
-
-            s = s.Trim();
-
-            return string.IsNullOrEmpty(s) ? null : s;
-        }
-
-        // regex to match the convention in title (first parentheses)
-        static readonly Regex _conventionRegex = new Regex(@"^\((?<conv>.*?)\)", RegexOptions.Compiled | RegexOptions.Singleline);
-
-        public static string FindConvention(string s)
-        {
-            if (string.IsNullOrEmpty(s))
-                return null;
-
-            return _conventionRegex.Match(s.TrimStart()).Groups["conv"].Value;
-        }
-
-        /// <summary>
-        /// Some books are incorrectly tagged with a pipe separator.
-        /// </summary>
-        public static IEnumerable<string> ProcessTag(nhentaiBook.TagData tag) => tag.Name.Split('|', StringSplitOptions.RemoveEmptyEntries);
-
-        public override BookBase Book => new BookBase
-        {
-            PrimaryName = FixTitle(_book.Title.Japanese) ?? FixTitle(_book.Title.English),
-            EnglishName = FixTitle(_book.Title.English) ?? FixTitle(_book.Title.Japanese),
-
-            Tags = new Dictionary<BookTag, string[]>
-            {
-                [BookTag.Artist]     = _book.Tags?.Where(t => t.Type == "artist").ToArrayMany(ProcessTag),
-                [BookTag.Tag]        = _book.Tags?.Where(t => t.Type == "tag").ToArrayMany(ProcessTag),
-                [BookTag.Parody]     = _book.Tags?.Where(t => t.Type == "parody" && t.Name != "original").ToArrayMany(ProcessTag),
-                [BookTag.Character]  = _book.Tags?.Where(t => t.Type == "character").ToArrayMany(ProcessTag),
-                [BookTag.Convention] = new[] { FindConvention(_book.Title.English ?? _book.Title.Japanese) },
-                [BookTag.Circle]     = _book.Tags?.Where(t => t.Type == "group").ToArrayMany(ProcessTag)
-            },
-
-            Category = Enum.TryParse<BookCategory>(_book.Tags?.FirstOrDefault(t => t.Type == "category")?.Name, true, out var category) ? category : BookCategory.Doujinshi,
-            Rating   = MaterialRating.Explicit, // explicit by default
-        };
-
-        public override IEnumerable<ContentAdaptor> Contents => new[] { new nhentaiContentAdaptor(_book) };
-    }
-
-    public class nhentaiContentAdaptor : BookAdaptor.ContentAdaptor
-    {
-        readonly nhentaiBook _book;
-
-        public nhentaiContentAdaptor(nhentaiBook book)
-        {
-            _book = book;
-        }
-
-        public override string Id => _book.Id.ToString();
-        public override int Pages => _book.Images.Pages.Length;
-
-        public override string Data => nhentaiScraper.DataContainer.Serialize(new nhentaiScraper.DataContainer
-        {
-            MediaId    = _book.MediaId,
-            Extensions = string.Concat(_book.Images.Pages.Select(p => p.Type))
-        });
-
-        public override BookContentBase Content => new BookContentBase
-        {
-            Language = _book.Tags?.FirstOrDefault(t => t.Type == "language" && t.Name != "translated")?.Name.ParseAsLanguage() ?? LanguageType.Japanese
-        };
-    }
-
     public class nhentaiScraperOptions : ScraperOptions
     {
         /// <summary>

--- a/nhitomi-idx/nhitomi/Scrapers/nhentaiScraper.cs
+++ b/nhitomi-idx/nhitomi/Scrapers/nhentaiScraper.cs
@@ -110,9 +110,9 @@ namespace nhitomi.Scrapers
             Tags = new Dictionary<BookTag, string[]>
             {
                 [BookTag.Artist]     = _book.Tags?.Where(t => t.Type == "artist").ToArrayMany(ProcessTag),
-                [BookTag.Parody]     = _book.Tags?.Where(t => t.Type == "tag").ToArrayMany(ProcessTag),
-                [BookTag.Character]  = _book.Tags?.Where(t => t.Type == "parody" && t.Name != "original").ToArrayMany(ProcessTag),
-                [BookTag.Convention] = _book.Tags?.Where(t => t.Type == "character").ToArrayMany(ProcessTag),
+                [BookTag.Tag]        = _book.Tags?.Where(t => t.Type == "tag").ToArrayMany(ProcessTag),
+                [BookTag.Parody]     = _book.Tags?.Where(t => t.Type == "parody" && t.Name != "original").ToArrayMany(ProcessTag),
+                [BookTag.Character]  = _book.Tags?.Where(t => t.Type == "character").ToArrayMany(ProcessTag),
                 [BookTag.Convention] = new[] { FindConvention(_book.Title.English ?? _book.Title.Japanese) },
                 [BookTag.Circle]     = _book.Tags?.Where(t => t.Type == "group").ToArrayMany(ProcessTag)
             },

--- a/nhitomi-idx/nhitomi/Startup.cs
+++ b/nhitomi-idx/nhitomi/Startup.cs
@@ -224,10 +224,12 @@ namespace nhitomi
                     .AddSingleton<IResourceLocker, RedisResourceLocker>();
 
             // scrapers
-            services.Configure<nhentaiScraperOptions>(_configuration.GetSection("Scrapers:nhentai"));
-
             services.AddSingleton<IScraperService, ScraperService>()
-                    .AddScraper<nhentaiScraper>();
+                    .AddInjectableHostedService<IBookIndexer, BackgroundBookIndexer>();
+
+            services.Configure<nhentaiScraperOptions>(_configuration.GetSection("Scrapers:nhentai"));
+            services.AddInjectableHostedService<nhentaiScraper>();
+            services.AddSingleton<IScraper>(s => s.GetService<nhentaiScraper>());
 
             // discord
             services.Configure<DiscordOptions>(_configuration.GetSection("Discord"))

--- a/nhitomi-idx/nhitomi/Startup.cs
+++ b/nhitomi-idx/nhitomi/Startup.cs
@@ -225,7 +225,7 @@ namespace nhitomi
 
             // scrapers
             services.AddSingleton<IScraperService, ScraperService>()
-                    .AddInjectableHostedService<IBookIndexer, BackgroundBookIndexer>();
+                    .AddSingleton<IBookIndexer, BookIndexer>();
 
             services.Configure<nhentaiScraperOptions>(_configuration.GetSection("Scrapers:nhentai"));
             services.AddInjectableHostedService<nhentaiScraper>();

--- a/nhitomi-idx/nhitomi/StartupServiceExtensions.cs
+++ b/nhitomi-idx/nhitomi/StartupServiceExtensions.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using nhitomi.Scrapers;
 
 namespace nhitomi
 {
@@ -19,12 +18,13 @@ namespace nhitomi
             return builder;
         }
 
-        public static IServiceCollection AddInjectableHostedService<T>(this IServiceCollection collection) where T : class, IHostedService
-            => collection.AddSingleton<T>()
-                         .AddTransient<IHostedService>(o => o.GetService<T>()); // transient because https://github.com/dotnet/extensions/issues/553#issuecomment-404547620
+        public static IServiceCollection AddInjectableHostedService<TService>(this IServiceCollection collection) where TService : class, IHostedService
+            => collection.AddSingleton<TService>()
+                         .AddTransient<IHostedService>(s => s.GetService<TService>()); // transient because https://github.com/dotnet/extensions/issues/553#issuecomment-404547620
 
-        public static IServiceCollection AddScraper<T>(this IServiceCollection collection) where T : class, IScraper
-            => collection.AddInjectableHostedService<T>()
-                         .AddSingleton<IScraper>(o => o.GetService<T>());
+        public static IServiceCollection AddInjectableHostedService<TService, TImplementation>(this IServiceCollection collection) where TService : class where TImplementation : class, TService, IHostedService
+            => collection.AddSingleton<TImplementation>()
+                         .AddSingleton<TService, TImplementation>(s => s.GetService<TImplementation>())
+                         .AddTransient<IHostedService>(o => o.GetService<TImplementation>());
     }
 }

--- a/nhitomi-web/src/Client/index.ts
+++ b/nhitomi-web/src/Client/index.ts
@@ -32,7 +32,7 @@ export class Client extends (EventEmitter as new () => StrictEventEmitter<EventE
         }
 
         // validation failure (unprocessable entity)
-        if (response.status === 422) {
+        else if (response.status === 422) {
           const result: ValidationProblemArrayResult = await response.json()
 
           throw new ValidationError(result.message, result.value)

--- a/nhitomi-web/src/ClientContext.tsx
+++ b/nhitomi-web/src/ClientContext.tsx
@@ -1,12 +1,9 @@
-import { createContext, ReactNode, useState, useMemo, useEffect, useContext, useRef } from 'react'
+import { createContext, ReactNode, useState, useMemo, useEffect, useContext } from 'react'
 import { Client } from './Client'
-import { useAsync, useThrottleFn } from 'react-use'
+import { useAsync } from 'react-use'
 import React from 'react'
-import { Modal, Divider } from 'antd'
-import { ApiOutlined } from '@ant-design/icons'
 import { ProgressContext } from './Progress'
 import { LocaleContext } from './LocaleProvider'
-import { FormattedMessage } from 'react-intl'
 
 /** API client context. */
 export const ClientContext = createContext<Client>(undefined as any)
@@ -21,19 +18,14 @@ export const ClientProvider = ({ children }: { children?: ReactNode }) => {
 
   // reset app completely when token changes
   const [reset, setReset] = useState(0)
-  const resetTimeout = useRef<number>()
 
   useEffect(() => {
-    resetTimeout.current && clearTimeout(resetTimeout.current)
-
     const handle = () => setReset(reset + 1)
 
     client.config.on('token', handle)
-
     return () => { client.config.off('token', handle) }
   }, [client, reset])
 
-  // initialize client
   useAsync(async () => {
     setInitialized(false)
 
@@ -47,48 +39,20 @@ export const ClientProvider = ({ children }: { children?: ReactNode }) => {
     }
     catch (e) {
       setInitialized(e)
-      resetTimeout.current = window.setTimeout(() => setReset(reset + 1), 5000)
     }
   }, [reset])
 
-  const initializing = !initialized || initialized instanceof Error
-
-  // initializing progress
   useEffect(() => {
-    if (initializing)
-      start()
-    else
+    if (initialized)
       stop()
-  }, [initializing]) // eslint-disable-line
+    else
+      start()
+  }, [!!initialized]) // eslint-disable-line
 
-  // retry hook
-  useThrottleFn(() => {
-    if (initialized instanceof Error)
-      setInitialized(false)
-  }, 5000, [initialized] as any)
+  if (initialized instanceof Error)
+    return <code>{initialized.stack}</code>
 
   return <ClientContext.Provider key={reset} value={client}>
-    {initialized && !(initialized instanceof Error) && children}
-
-    {initialized instanceof Error && <ErrorDisplay error={initialized} />}
+    {initialized && children}
   </ClientContext.Provider>
-}
-
-const ErrorDisplay = ({ error }: { error: Error }) => {
-  return <Modal
-    visible
-    closable={false}
-    footer={null}
-    title={<>
-      <ApiOutlined />
-      {' '}
-      <FormattedMessage id='api.connectionFailed.title' />
-    </>}>
-
-    <p><FormattedMessage id='api.connectionFailed.description' /></p>
-    <br />
-    <Divider />
-    <p><strong>{error.name}</strong>: {error.message || '<unknown reason>'}</p>
-    <p><code>{error.stack}</code></p>
-  </Modal>
 }


### PR DESCRIPTION
Instead of naively searching for similar books and merging one-by-one, we now merge books in-memory first "dry merge" using dictionaries, and then index unmergeable books in bulk as one request.

1. Efficiently merge books in-memory using dictionaries and sets.
2. Go through books one-by-one, searching for similar books in the database. If found, merge immediately. Otherwise, add to bulk create request.
3. Send unmerged books as one request.
4. All this is done with Elasticsearch refresh parameter set to immediate.